### PR TITLE
allow bigWig files to also have .bigwig or .bigWig extensions

### DIFF
--- a/src/commandParser.c
+++ b/src/commandParser.c
@@ -31,7 +31,7 @@ puts("");
 puts("This library parses wiggle files and executes various operations on them streaming through lazy evaluators.");
 puts("");
 puts("Inputs:");
-puts("\tThe program takes in Wig, BigWig, BedGraph, Bed, BigBed, Bam, VCF, and BCF files, which are distinguished thanks to their suffix (.wig, .bw, .bg, .bed, .bb, .bam, .vcf, .bcf respectively).");
+puts("\tThe program takes in Wig, BigWig, BedGraph, Bed, BigBed, Bam, VCF, and BCF files, which are distinguished thanks to their suffix (.wig, (.bw|.bigWig|.bigwig), .bg, .bed, .bb, .bam, .vcf, .bcf respectively).");
 puts("\tNote that wiggletools assumes that every bam file has an index .bai file next to it.");
 puts("");
 puts("Outputs:");

--- a/src/unaryOps.c
+++ b/src/unaryOps.c
@@ -1021,6 +1021,10 @@ WiggleIterator * SmartReader(char * filename, bool holdFire) {
 	size_t length = strlen(filename);
 	if (!strcmp(filename + length - 3, ".bw"))
 		return BigWiggleReader(filename, holdFire);
+	else if (!strcmp(filename + length - 7, ".bigWig"))
+		return BigWiggleReader(filename, holdFire);
+	else if (!strcmp(filename + length - 7, ".bigwig"))
+		return BigWiggleReader(filename, holdFire);
 	else if (!strcmp(filename + length - 3, ".bg"))
 		return WiggleReader(filename);
 	else if (!strcmp(filename + length - 4, ".wig"))


### PR DESCRIPTION
 (.bigWig appears to be preferred by ENCODE at encodeproject.org)