### PR TITLE
openssl version update to fix missing file error

### DIFF
--- a/easy_install.sh
+++ b/easy_install.sh
@@ -68,7 +68,7 @@ install_ssl () {
 		brew install openssl
 	else 
 		rm -Rf openssl*
-		confirmed_download 'OpenSSl' 'ftp://ftp.openssl.org/source/openssl-1.0.1h.tar.gz'
+		confirmed_download 'OpenSSl' 'ftp://ftp.openssl.org/source/openssl-1.0.1t.tar.gz'
 		cd openssl*
 			./config
 			make


### PR DESCRIPTION
During easy_install, openssl library fails to download file. I've updated the version to an existing file.

```
./easy_install.sh 
Checking for Zlib...
Checking for OpenSSL...
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
About to install OpenSSl
I will download from ftp://ftp.openssl.org/source/openssl-1.0.1h.tar.gz
OK? (Yes/abort)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (78) RETR response: 550
```