### PR TITLE
Implementation for toInt

### DIFF
--- a/src/commandParser.c
+++ b/src/commandParser.c
@@ -1,11 +1,11 @@
 // Copyright [1999-2017] EMBL-European Bioinformatics Institute
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -46,7 +46,7 @@ puts("");
 puts("Program grammar:");
 puts("\tprogram = (iterator) | do (iterator) | (extraction) | (statistic) | run (file)");
 puts("\titerator = (in_filename) | (unary_operator) (iterator) | (binary_operator) (iterator) (iterator) | (reducer) (multiplex) | (setComparison) (multiplex_list) | print (output) (statistic)");
-puts("\tunary_operator = unit | coverage | write (output) | write_bg (ouput) | smooth (int) | abs | exp | ln | log (float) | pow (float) | offset (float) | scale (float) | gt (float) | lt (float) | default (float) | isZero | floor | extend (int) | bin (int) | (statistic)");
+puts("\tunary_operator = unit | coverage | write (output) | write_bg (ouput) | smooth (int) | abs | exp | ln | log (float) | pow (float) | offset (float) | scale (float) | gt (float) | lt (float) | default (float) | isZero | toInt | floor | extend (int) | bin (int) | (statistic)");
 puts("\toutput = (out_filename) | -");
 puts("\tin_filename = *.wig | *.bw | *.bed | *.bb | *.bg | *.bam | *.cram | *.vcf | *.bcf");
 puts("\tstatistic = (statistic_function) (iterator) | ndpearson (multiplex) (multiplex)");
@@ -242,7 +242,7 @@ static FILE * readOutputFilename() {
 			exit(1);
 		}
 		return file;
-	} else 
+	} else
 		return stdout;
 }
 
@@ -317,7 +317,7 @@ static Multiplexer * readMultiplexerToken(char * token) {
 	} else if (strcmp(token, "apply") == 0) {
 		return readApply();
 	} else {
-		int count = 0; 
+		int count = 0;
 		bool strict = false;
 		WiggleIterator ** iters = readIteratorListToken(&count, &strict, token);
 		return newMultiplexer(iters, count, strict);
@@ -618,7 +618,7 @@ static WiggleIterator * readMeanIntegrator() {
 }
 
 static WiggleIterator * readMaxIntegrator() {
-	return MaxIntegrator(readIterator());	
+	return MaxIntegrator(readIterator());
 }
 
 static WiggleIterator * readMinIntegrator() {
@@ -626,15 +626,15 @@ static WiggleIterator * readMinIntegrator() {
 }
 
 static WiggleIterator * readVarianceIntegrator() {
-	return VarianceIntegrator(readIterator());	
+	return VarianceIntegrator(readIterator());
 }
 
 static WiggleIterator * readStandardDeviationIntegrator() {
-	return StandardDeviationIntegrator(readIterator());	
+	return StandardDeviationIntegrator(readIterator());
 }
 
 static WiggleIterator * readCoefficientOfVariationIntegrator() {
-	return CoefficientOfVariationIntegrator(readIterator());	
+	return CoefficientOfVariationIntegrator(readIterator());
 }
 
 static WiggleIterator * readEnergy() {
@@ -666,6 +666,10 @@ static WiggleIterator * readIsZero() {
 
 static WiggleIterator * readFloor() {
 	return Floor(readIterator());
+}
+
+static WiggleIterator * readToInt() {
+	return ToInt(readIterator());
 }
 
 static WiggleIterator * readIteratorToken(char * token) {
@@ -773,8 +777,10 @@ static WiggleIterator * readIteratorToken(char * token) {
 		return readNDPearson();
 	if (strcmp(token, "isZero") == 0)
 		return readIsZero();
-    if (strcmp(token, "floor") == 0)
-        return readFloor();
+	if (strcmp(token, "floor") == 0)
+		return readFloor();
+	if (strcmp(token, "toInt") == 0)
+		return readToInt();
 	if (strcmp(token, "apply") == 0)
 		return SelectReduction(readApply(), 0);
 
@@ -830,9 +836,9 @@ static void readProfiles() {
 static void readHistogram() {
 	FILE * file = readOutputFilename();
 	int width = atoi(needNextToken());
-	int count = 0; 
+	int count = 0;
 	WiggleIterator ** iters = readLastIteratorList(&count);
-	Histogram * hist = histogram(iters, count, width);	
+	Histogram * hist = histogram(iters, count, width);
 	print_histogram(hist, file);
 	fclose(file);
 }
@@ -924,5 +930,5 @@ void rollYourOwn(int argc, char ** argv) {
 	else if (strcmp(token, "run") == 0)
 		parseFile(needNextToken());
 	else
-		toStdout(readLastIteratorToken(token), false, false);	
+		toStdout(readLastIteratorToken(token), false, false);
 }

--- a/src/unaryOps.c
+++ b/src/unaryOps.c
@@ -167,6 +167,7 @@ void toIntPop(WiggleIterator * wi) {
 	wi->finish = data->iter->finish;
 	wi->value = (int)(data->iter->value);
 	pop(data->iter);
+}
 
 WiggleIterator * ToInt(WiggleIterator * wi) {
 	UnaryWiggleIteratorData * data = (UnaryWiggleIteratorData *) calloc(1, sizeof(UnaryWiggleIteratorData));

--- a/src/unaryOps.c
+++ b/src/unaryOps.c
@@ -1,11 +1,11 @@
 // Copyright [1999-2017] EMBL-European Bioinformatics Institute
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -75,11 +75,11 @@ void UnionWiggleIteratorPop(WiggleIterator * wi) {
 		} else if (wi->chrom == iter->chrom && wi->finish >= iter->start) {
 			if (iter->finish > wi->finish)
 				wi->finish = iter->finish;
-		} else 
+		} else
 			break;
 		count++;
 		pop(iter);
-	} 
+	}
 
 	wi->done = (count == 0);
 }
@@ -146,10 +146,32 @@ void floorPop(WiggleIterator * wi) {
     wi->value = floor(data->iter->value);
 	pop(data->iter);
 }
+
 WiggleIterator * Floor(WiggleIterator * wi) {
 	UnaryWiggleIteratorData * data = (UnaryWiggleIteratorData *) calloc(1, sizeof(UnaryWiggleIteratorData));
 	data->iter = wi;
 	return newWiggleIterator(data, &floorPop, &UnaryWiggleIteratorSeek, floor(wi->default_value));
+}
+//////////////////////////////////////////////////////
+// toInt
+//////////////////////////////////////////////////////
+
+void toIntPop(WiggleIterator * wi) {
+	UnaryWiggleIteratorData * data = (UnaryWiggleIteratorData *) wi->data;
+	if (data->iter->done) {
+		wi->done = true;
+		return;
+	}
+	wi->chrom = data->iter->chrom;
+	wi->start = data->iter->start;
+	wi->finish = data->iter->finish;
+	wi->value = (int)(data->iter->value);
+	pop(data->iter);
+
+WiggleIterator * ToInt(WiggleIterator * wi) {
+	UnaryWiggleIteratorData * data = (UnaryWiggleIteratorData *) calloc(1, sizeof(UnaryWiggleIteratorData));
+	data->iter = wi;
+	return newWiggleIterator(data, &toIntPop, &UnaryWiggleIteratorSeek, (int)(wi->default_value));
 }
 
 //////////////////////////////////////////////////////
@@ -420,8 +442,8 @@ void OverlapWiggleIteratorPop(WiggleIterator * wi) {
 			pop(source);
 		else
 			break;
-	} 
-	
+	}
+
 	if (source->done || mask->done)
 		wi->done = true;
 	else {
@@ -470,8 +492,8 @@ void TrimWiggleIteratorPop(WiggleIterator * wi) {
 			pop(source);
 		else
 			break;
-	} 
-	
+	}
+
 	if (source->done || mask->done)
 		wi->done = true;
 	else {
@@ -513,8 +535,8 @@ void NoverlapWiggleIteratorPop(WiggleIterator * wi) {
 			break;
 		else
 			pop(source);
-	} 
-	
+	}
+
 	if (source->done)
 		wi->done = true;
 	else {
@@ -570,8 +592,8 @@ void NearestWiggleIteratorPop(WiggleIterator * wi) {
 			pop(mask);
 		} else
 			break;
-	} 
-	
+	}
+
 	wi->chrom = source->chrom;
 	wi->start = source->start;
 	wi->finish = source->finish;
@@ -580,9 +602,9 @@ void NearestWiggleIteratorPop(WiggleIterator * wi) {
 	if (data->prev_chrom && strcmp(data->prev_chrom, source->chrom) == 0) {
 		wi->value = wi->start - data->prev_finish + 1;
 		set = true;
-	}	
+	}
 
-	if (!mask->done && strcmp(mask->chrom, source->chrom) == 0 && (!set || wi->value > mask->start - wi->finish + 1)) { 
+	if (!mask->done && strcmp(mask->chrom, source->chrom) == 0 && (!set || wi->value > mask->start - wi->finish + 1)) {
 		wi->value = mask->start - wi->finish + 1;
 		set = true;
 	}
@@ -590,7 +612,7 @@ void NearestWiggleIteratorPop(WiggleIterator * wi) {
 	if (!set)
 		wi->value = NAN;
 	else if (wi->value < 0)
-		wi->value = 0;	
+		wi->value = 0;
 
 	pop(source);
 }
@@ -948,7 +970,7 @@ static void BinningWiggleIteratorPop(WiggleIterator * wi) {
 			finish = wi->finish;
 		else
 			finish = iter->finish;
-	
+
 		int covered_length = finish - start;
 		wi->value += covered_length * iter->value;
 		total_covered_length += covered_length;
@@ -992,7 +1014,7 @@ typedef struct SmoothWiggleIteratorData_st {
 static double smoothWiggleIteratorRecomputeSum(SmoothWiggleIteratorData * data) {
        double sum = 0;
        int index;
-       if (data->oldest < data->latest)   
+       if (data->oldest < data->latest)
                for (index = data->oldest + 1; index < data->latest; index++)
                        sum += data->buffer[index];
        else {
@@ -1004,7 +1026,7 @@ static double smoothWiggleIteratorRecomputeSum(SmoothWiggleIteratorData * data) 
 
        return sum;
 }
-   
+
 static void smoothWiggleIteratorEraseOne(SmoothWiggleIteratorData * data) {
 	if (isnan(data->buffer[data->oldest]))
                data->sum = smoothWiggleIteratorRecomputeSum(data);
@@ -1021,13 +1043,13 @@ static void smoothWiggleIteratorReadOne(char * chrom, int position, SmoothWiggle
 	// Let iter run if necessary
 	while (!iter->done && iter->chrom == chrom && iter->finish <= position)
 		pop(iter);
-	
+
 	// Record iter's value as appropriate
 	if (!iter->done && iter->chrom == chrom) {
 		if (iter->start <= position) {
 			data->buffer[data->latest] = iter->value;
 			data->sum += iter->value;
-		} else 
+		} else
 			data->buffer[data->latest] = 0;
 		data->count++;
 		data->last_position = position;
@@ -1139,7 +1161,7 @@ WiggleIterator * SmartReader(char * filename, bool holdFire) {
 }
 
 //////////////////////////////////////////////////////
-// Concatenation 
+// Concatenation
 //////////////////////////////////////////////////////
 
 typedef struct CatWiggleIteratorData_st {
@@ -1175,7 +1197,7 @@ void CatWiggleIteratorPop(WiggleIterator * wi) {
 				break;
 			}
 		}
-	} else 
+	} else
 		wi->done = true;
 }
 

--- a/src/wiggletools.h
+++ b/src/wiggletools.h
@@ -1,11 +1,11 @@
 // Copyright [1999-2017] EMBL-European Bioinformatics Institute
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,11 +41,11 @@ WiggleIterator * SamReader (char *);
 WiggleIterator * VcfReader (char *);
 WiggleIterator * BcfReader (char *, bool);
 
-// Generic class functions 
+// Generic class functions
 void seek(WiggleIterator *, const char *, int, int);
 
 // Algebraic operations on iterators
-	
+
 	// Unary
 WiggleIterator * UnitWiggleIterator (WiggleIterator *);
 WiggleIterator * CoverageWiggleIterator (WiggleIterator *);
@@ -62,6 +62,7 @@ WiggleIterator * NoverlapWiggleIterator(WiggleIterator *, WiggleIterator *);
 WiggleIterator * NearestWiggleIterator(WiggleIterator *, WiggleIterator *);
 WiggleIterator * IsZero(WiggleIterator *);
 WiggleIterator * Floor(WiggleIterator *);
+WiggleIterator * ToInt(WiggleIterator *);
 	// Scalar operations
 WiggleIterator * ScaleWiggleIterator (WiggleIterator *, double);
 WiggleIterator * ShiftWiggleIterator(WiggleIterator *, double);
@@ -74,7 +75,7 @@ WiggleIterator * SmoothWiggleIterator(WiggleIterator * i, int);
 WiggleIterator * BinningWiggleIterator(WiggleIterator * i, int);
 WiggleIterator * ExtendWiggleIterator(WiggleIterator * i, int);
 
-// Sets of iterators 
+// Sets of iterators
 Multiplexer * newMultiplexer(WiggleIterator **, int, bool);
 
 // Reduction operators on sets
@@ -92,7 +93,7 @@ WiggleIterator * CVReduction ( Multiplexer * );
 WiggleIterator * MedianReduction ( Multiplexer * );
 WiggleIterator * FillInReduction( Multiplexer * );
 
-// Sets of sets iterators 
+// Sets of sets iterators
 Multiset * newMultiset(Multiplexer **, int);
 
 // Reduction operators on sets of sets:
@@ -123,7 +124,7 @@ WiggleIterator * NDPearsonIntegrator(Multiset *);
 WiggleIterator * EnergyIntegrator(WiggleIterator *, int);
 void regionProfile(WiggleIterator *, double *, int, int, bool);
 void addProfile(double *, double *, int);
-//	Binary 
+//	Binary
 WiggleIterator * PearsonIntegrator (WiggleIterator * , WiggleIterator * );
 //	Histograms
 Histogram * histogram(WiggleIterator **, int, int);

--- a/test/test.py
+++ b/test/test.py
@@ -27,19 +27,19 @@ assert test('../bin/wiggletools diff fixedStep.bw variableStep.wig fixedStep.wig
 # Positive control
 assert test('../bin/wiggletools do isZero diff fixedStep.bw fixedStep.wig') == 0
 
-# Testing ratios and offset 
+# Testing ratios and offset
 assert test('../bin/wiggletools do isZero offset -1 ratio variableStep.bw variableStep.wig') == 0
 
-# Testing BAM & BedGraph 
+# Testing BAM & BedGraph
 assert test('../bin/wiggletools do isZero diff bam.bam pileup.bg') == 0
 
-# Testing BAM & CRAM 
+# Testing BAM & CRAM
 assert test('../bin/wiggletools do isZero diff bam.bam cram.cram') == 0
 
-# Testing BAM & SAM 
+# Testing BAM & SAM
 assert test('../bin/wiggletools do isZero diff bam.bam sam.sam') == 0
 
-# Testing BAM & SAM 
+# Testing BAM & SAM
 assert test('cat sam.sam | ../bin/wiggletools do isZero diff bam.bam sam -') == 0
 
 # Testing Bed and BigBed
@@ -100,14 +100,17 @@ assert float(testOutput('../bin/wiggletools print - minI fixedStep.wig')) == 0
 # Test max
 assert float(testOutput('../bin/wiggletools print - maxI fixedStep.wig')) == 9
 
-# Test coverage 
+# Test coverage
 assert test('../bin/wiggletools do isZero diff overlapping_coverage.wig coverage overlapping.bed') == 0
 
 #Test trim
 assert test('../bin/wiggletools do isZero diff trim overlapping.bed variableStep.wig mult overlapping.bed variableStep.wig') == 0
 
 #Test floor
-assert test('../bin/wiggletools do floor fixedStep.wig') == 0
+assert test('../bin/wiggletools do isZero diff floor fixedStep.wig floor fixedStep.wig') == 0
+
+#Test toInt
+assert test('../bin/wiggletools do isZero diff toInt fixedStep.wig toInt variableStep.wig') == 1
 
 # Test program file
 assert test('../bin/wiggletools run program.txt') == 0


### PR DESCRIPTION
Instead of using floor, which is more expensive, a static cast toInt will accomplish the same thing.