### PR TITLE
Dockerize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:20.04 AS builder
+
+RUN apt update && apt install -y --no-install-recommends \
+  ca-certificates \
+  libgsl-dev \
+  libhts-dev \
+  libbigwig-dev \
+  libcurl4-openssl-dev \
+  gcc \
+  python \
+  make
+
+WORKDIR /WiggleTools
+
+COPY . .
+
+RUN make LIBS='-lwiggletools -lBigWig -lcurl -lhts -lgsl  -lgslcblas -lz -lpthread -lm -llzma' \
+  && make test
+
+FROM ubuntu:20.04
+
+RUN apt update && apt install -y --no-install-recommends \
+  ca-certificates \
+  libbigwig0 \
+  libcurl4 \
+  libgsl23 \
+  libhts3
+
+COPY --from=builder /WiggleTools/bin/wiggletools /usr/local/bin

--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ Brew Installation
 brew install brewsci/bio/wiggletools
 ```
 
+Docker Installation
+-----------------
+
+Build a WiggleTools Docker image:
+```
+docker build -t wiggletools .
+```
+
+Run the resulting wiggletools executable, bind-mounting the current working directory into the container:
+```
+docker run -v $PWD:/mnt -w /mnt --rm wiggletools wiggletools [...arguments...]
+```
+
 Pre-requisites
 --------------
 


### PR DESCRIPTION
It can be convenient Dockerfile that formalizes build requirements & facilitates a reproducible build. This example uses a multi-stage build to build & test in the first stage, with the resulting slimmer image containing only the wiggletools executable and shared library dependencies.