### PR TITLE
Minor build improvement and fabs() bug fix (probably)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,7 @@ bin: ${BINDIR}/wiggletools
 
 ${BINDIR}/wiggletools: ${LIBDIR}/libwiggletools.a wiggletools.o
 	mkdir -p ${BINDIR}
-	${CC} ${CFLAGS} -L${LIBDIR} wiggletools.c ${LIBS} -o ${BINDIR}/wiggletools 
+	${CC} ${CFLAGS} -L${LIBDIR} ${LDFLAGS} wiggletools.c ${LIBS} -o ${BINDIR}/wiggletools
 
 lib: ${LIBDIR}/libwiggletools.a 
 
@@ -18,7 +18,7 @@ ${LIBDIR}/libwiggletools.a: wiggleIterator.o wigReader.o bigWiggleReader.o multi
 	mkdir -p ${LIBDIR}
 	ar rcs ${LIBDIR}/libwiggletools.a *.o
 
-%.o: %.c; ${CC} ${CFLAGS} ${INC} ${OPTS} -c $< -o $@
+%.o: %.c; ${CC} ${CFLAGS} ${INC} ${CPPFLAGS} ${OPTS} -c $< -o $@
 
 clean:
 	rm -Rf *.o *.a wiggletools

--- a/src/unaryOps.c
+++ b/src/unaryOps.c
@@ -939,7 +939,7 @@ static void AbsWiggleIteratorPop(WiggleIterator * wi) {
 		wi->start = iter->start;
 		wi->finish = iter->finish;
 		if (!isnan(iter->value))
-			wi->value = abs(iter->value);
+			wi->value = fabs(iter->value);
 		else
 			wi->value = NAN;
 		pop(iter);
@@ -953,7 +953,7 @@ WiggleIterator * AbsWiggleIterator(WiggleIterator * i) {
 	data->iter = NonOverlappingWiggleIterator(i);
 	double default_value;
 	if (!isnan(i->default_value))
-		default_value = abs(i->default_value);
+		default_value = fabs(i->default_value);
 	else
 		default_value = NAN;
 	return newWiggleIterator(data, &AbsWiggleIteratorPop, &UnaryWiggleIteratorSeek, default_value, i->overlaps);


### PR DESCRIPTION
Hi Daniel,

A small build improvement, and a warning fix that changes `wiggletools abs` output for fractions — hopefully for the better:

* Use the standard CPPFLAGS and LDFLAGS as appropriate in the Makefile, so that users and packagers can easily tweak the build if necessary. (e.g. Bioconda will be able to use this to simplify their wiggletools recipe.)

* Fix `abs`/`fabs` warnings in _unaryOps.c_ — this alters the output of `wiggletools abs foo.wig` for lines with fractional values (if that can happen in these files), outputting the value as input rather than truncating it to an integer — which is hopefully an improvement.